### PR TITLE
Fix GPG error: NO_PUBKEY

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:10.2-runtime-ubuntu18.04
 
-RUN apt-get update && \
+RUN apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub && \
+    apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y wget mc tmux nano build-essential rsync libgl1
 

--- a/docker/Dockerfile-cuda111
+++ b/docker/Dockerfile-cuda111
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:11.1-runtime-ubuntu18.04
 
-RUN apt-get update && \
+RUN apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub && \
+    apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y wget mc tmux nano build-essential rsync libgl1
 


### PR DESCRIPTION
In building the image from the official Dockerfile using a cloud image-building service, normally we will get the following errors and cause a failure:
```
W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 InRelease' is not signed.
```

To solve that, I checked this link(https://forums.developer.nvidia.com/t/gpg-error-http-developer-download-nvidia-com-compute-cuda-repos-ubuntu1804-x86-64/212904) from NVIDIA Developer Forums and got the suggestion of adding the following command:
```
sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub
```