### PR TITLE
[fix] l1_loss masking sign reversed

### DIFF
--- a/saicinpainting/evaluation/refinement.py
+++ b/saicinpainting/evaluation/refinement.py
@@ -78,7 +78,7 @@ def _l1_loss(
     image : torch.Tensor, on_pred : bool=True
     ):
     """l1 loss on src pixels, and downscaled predictions if on_pred=True"""
-    loss = torch.mean(torch.abs(pred[mask<1e-8] - image[mask<1e-8]))
+    loss = torch.mean(torch.abs(pred[mask>=1e-8] - image[mask>=1e-8]))
     if on_pred: 
         loss += torch.mean(torch.abs(pred_downscaled[mask_downscaled>=1e-8] - ref[mask_downscaled>=1e-8]))                
     return loss


### PR DESCRIPTION
When calculating l1 loss, loss should derive from masked area but the sign was reversed.
Could you please check this out? @windj007 @ankuPRK 