### PR TITLE
Add 3rd party apps: demo&training samples in the largest Model Community in Chinese (ModelScope)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ LaMa generalizes surprisingly well to much higher resolutions (~2k❗️) than i
 - [Auto-LaMa](https://github.com/andy971022/auto-lama) = DE:TR object detection + LaMa inpainting by [@andy971022](https://github.com/andy971022)
 - [LAMA-Magic-Eraser-Local](https://github.com/zhaoyun0071/LAMA-Magic-Eraser-Local) = a standalone inpainting application built with PyQt5 by [@zhaoyun0071](https://github.com/zhaoyun0071)
 - [Hama](https://www.hama.app/) - object removal with a smart brush which simplifies mask drawing.
+- [ModelScope](https://www.modelscope.cn/models/damo/cv_fft_inpainting_lama/summary) = the largest Model Community in Chinese.
 
 # Environment setup
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ LaMa generalizes surprisingly well to much higher resolutions (~2k❗️) than i
 - [Auto-LaMa](https://github.com/andy971022/auto-lama) = DE:TR object detection + LaMa inpainting by [@andy971022](https://github.com/andy971022)
 - [LAMA-Magic-Eraser-Local](https://github.com/zhaoyun0071/LAMA-Magic-Eraser-Local) = a standalone inpainting application built with PyQt5 by [@zhaoyun0071](https://github.com/zhaoyun0071)
 - [Hama](https://www.hama.app/) - object removal with a smart brush which simplifies mask drawing.
-- [ModelScope](https://www.modelscope.cn/models/damo/cv_fft_inpainting_lama/summary) = the largest Model Community in Chinese.
+- [ModelScope](https://www.modelscope.cn/models/damo/cv_fft_inpainting_lama/summary) = the largest Model Community in Chinese by  [@chenbinghui1](https://github.com/chenbinghui1).
 
 # Environment setup
 


### PR DESCRIPTION
Tanks for your wonderful work. 

Now we add the 3rd party support for LaMa in our [ModelScope](https://www.modelscope.cn/models/damo/cv_fft_inpainting_lama/summary), the largest Model Community in Chinese now. We hope that the link to demo of lama in ModelScope can be added to the readme file.

Tanks again!