### PR TITLE
Fix tuple error, mentioned in some of the issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ LaMa generalizes surprisingly well to much higher resolutions (~2k❗️) than i
   <img src="https://raw.githubusercontent.com/geekyutao/Inpaint-Anything/main/example/MainFramework.png" />
 </p>
 
-- [Feature Refinement to Improve High Resolution Image Inpainting](https://arxiv.org/abs/2206.13644) / [video](https://www.youtube.com/watch?v=gEukhOheWgE) / code https://github.com/advimman/lama/pull/112 / by Geomagical Labs ([geomagical.com](geomagical.com))
+- [Feature Refinement to Improve High Resolution Image Inpainting](https://arxiv.org/abs/2206.13644) / [video](https://www.youtube.com/watch?v=gEukhOheWgE) / code https://github.com/advimman/lama/pull/112 / by Geomagical Labs ([geomagical.com](https://www.geomagical.com))
 <p align="center">
   <img src="https://raw.githubusercontent.com/senya-ashukha/senya-ashukha.github.io/master/images/FeatureRefinement.png" />
 </p>

--- a/saicinpainting/evaluation/refinement.py
+++ b/saicinpainting/evaluation/refinement.py
@@ -83,6 +83,27 @@ def _l1_loss(
         loss += torch.mean(torch.abs(pred_downscaled[mask_downscaled>=1e-8] - ref[mask_downscaled>=1e-8]))                
     return loss
 
+def feats_type_to_list(feats, feats_type):
+    """unpacks the tuple of features into a list"""
+    if feats_type == tuple:
+        feats = list(feats)
+    elif feats_type == torch.Tensor:
+        feats = [feats]
+    else:
+        raise NotImplementedError("Expected the output of forward_front to be a tuple or a tensor!")
+    return feats
+
+def list_to_feats_type(feats, feats_type):
+    """packs the list of features into the original feature type"""
+    if feats_type == tuple:
+        feats = tuple(feats)
+    elif feats_type == torch.Tensor:
+        feats = feats[0]
+    else:
+        raise NotImplementedError("Expected the output of forward_front to be a tuple or a tensor!")
+    return feats
+
+
 def _infer(
     image : torch.Tensor, mask : torch.Tensor, 
     forward_front : nn.Module, forward_rears : nn.Module, 
@@ -126,13 +147,8 @@ def _infer(
         ref_lower_res = ref_lower_res.detach()
     with torch.no_grad():
         z_feats = forward_front(masked_image)
-        z_feat_type = type(z_feats)
-        if z_feat_type == tuple:
-            z_feats = list(z_feats)
-        elif z_feat_type == torch.Tensor:
-            z_feats = [z_feats]
-        else:
-            raise NotImplementedError("Expected the output of forward_front to be a tuple or a tensor!")
+        z_feats_type = type(z_feats)
+        z_feats = feats_type_to_list(z_feats, z_feats_type)
     # Inference
     mask = mask.to(devices[-1])
     ekernel = torch.from_numpy(cv2.getStructuringElement(cv2.MORPH_ELLIPSE,(15,15)).astype(bool)).float()
@@ -147,16 +163,13 @@ def _infer(
     pbar = tqdm(range(n_iters), leave=False)
     for idi in pbar:
         optimizer.zero_grad()
-        if z_feat_type == tuple:
-            input_feat = tuple(z_feats)
-        elif z_feat_type == torch.Tensor:
-            input_feat = z_feats[0]
+        input_feat = list_to_feats_type(z_feats, z_feats_type)
         for idd, forward_rear in enumerate(forward_rears):
             output_feat = forward_rear(input_feat)
             if idd < len(devices) - 1:
-                midz1, midz2 = output_feat
-                midz1, midz2 = midz1.to(devices[idd+1]), midz2.to(devices[idd+1])
-                input_feat = (midz1, midz2)
+                mid_z_feats = feats_type_to_list(output_feat, z_feats_type)
+                mid_z_feats = [mid_z_feat.to(devices[idd+1]) for mid_z_feat in mid_z_feats]
+                input_feat = list_to_feats_type(mid_z_feats, z_feats_type)
             else:        
                 pred = output_feat
 

--- a/saicinpainting/evaluation/refinement.py
+++ b/saicinpainting/evaluation/refinement.py
@@ -103,7 +103,6 @@ def list_to_feats_type(feats, feats_type):
         raise NotImplementedError("Expected the output of forward_front to be a tuple or a tensor!")
     return feats
 
-
 def _infer(
     image : torch.Tensor, mask : torch.Tensor, 
     forward_front : nn.Module, forward_rears : nn.Module, 


### PR DESCRIPTION
## Summary

- We see some GitHub issues when some folks were trying to use the refinement step for non-fourier models. So we add a fix for that.
- (minor) We also correct a typo in the website link to Geomagical.com

## Issues

https://github.com/advimman/lama/issues/274
https://github.com/advimman/lama/issues/167

## Problem

In the lama-regular model, the latent feature is a single Tensor, while in lama-fourier and big-lama, the latent feature is a tuple of two tensors. In our refinement code, we assumed the feature to be a tuple. 

## Solution

This PR adds a function that adapts the feature appropriately. We can't just keep it as-it-is because when Pytorch optimizers (like Adam) don't take a tuple as input.

## Visual Results

- Input Images
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/7ce99dd1-62c0-48aa-9e9c-5a886efae88f)
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/c573f08a-667c-4ca2-a155-8d8b1438b17b)

- Big LaMa (before and after refinement)
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/7ef4d5c4-cc33-48f0-bc4e-9ad09075ad9a)
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/a5e910af-4a93-4be2-a4e9-f4660377d448)
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/febd0e5b-b598-4c90-9483-ba6a20e8bc57)
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/72af7146-03ff-4852-9d2f-5593cae33bd1)

- LaMa-Fourier (before and after refinement, of course, parameters tuned to this model could make results even better)
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/da1fe5a5-4563-4365-bb26-811b0bb8d669)
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/dd41a0ee-c38b-4df9-8882-787ef012e728)
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/5b625055-014b-496f-ad00-aa6b60c621e8)
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/a9088bdf-dbc0-478a-81c5-a6ab7e562598)

- LaMa-Regular (the one on which refinement was failing)
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/a9cc3062-5e39-419a-85ed-6ece1900aedc)
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/5d7f51e6-fd06-4680-9ad2-701fc49b8b48)
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/9e16fea0-f991-4bbc-b619-9dfa3d7562c6)
![image](https://github.com/geomagical/lama-with-refiner/assets/13609663/9024b2f3-73f5-4e0b-80f0-17a8290034e5)
