### PR TITLE
Adding capability to start a training from model checkpoint instead of doing it from scratch

### DIFF
--- a/bin/train.py
+++ b/bin/train.py
@@ -18,7 +18,7 @@ from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.plugins import DDPPlugin
 
-from saicinpainting.training.trainers import make_training_model
+from saicinpainting.training.trainers import make_training_model, load_checkpoint
 from saicinpainting.utils import register_debug_signal_handlers, handle_ddp_subprocess, handle_ddp_parent_process, \
     handle_deterministic_config
 
@@ -48,7 +48,15 @@ def main(config: OmegaConf):
         metrics_logger = TensorBoardLogger(config.location.tb_dir, name=os.path.basename(os.getcwd()))
         metrics_logger.log_hyperparams(config)
 
-        training_model = make_training_model(config)
+        if "load_checkpoint_path" in config.location:
+            print("Loading model checkpoint from path:", config.location.load_checkpoint_path)
+            training_model = load_checkpoint(
+                train_config=config,
+                path=config.location.load_checkpoint_path,
+                strict=False
+            )
+        else:
+            training_model = make_training_model(config)
 
         trainer_kwargs = OmegaConf.to_container(config.trainer.kwargs, resolve=True)
         if need_set_deterministic:

--- a/configs/training/location/celeba_example.yaml
+++ b/configs/training/location/celeba_example.yaml
@@ -3,3 +3,5 @@ data_root_dir: /home/user/lama/celeba-hq-dataset/
 out_root_dir: /home/user/lama/experiments/
 tb_dir: /home/user/lama/tb_logs/
 pretrained_models: /home/user/lama/
+# path to model checkpoint that will be loaded before start of training
+# load_checkpoint_path: /home/user/lama/big-lama/models/best.ckpt

--- a/configs/training/location/docker.yaml
+++ b/configs/training/location/docker.yaml
@@ -3,3 +3,5 @@ data_root_dir: /data/data
 out_root_dir: /data/experiments
 tb_dir: /data/tb_logs
 pretrained_models: /some_path
+# path to model checkpoint that will be loaded before start of training
+# load_checkpoint_path: /home/user/lama/big-lama/models/best.ckpt

--- a/configs/training/location/places_example.yaml
+++ b/configs/training/location/places_example.yaml
@@ -3,3 +3,5 @@ data_root_dir: /home/user/inpainting-lama/places_standard_dataset/
 out_root_dir: /home/user/inpainting-lama/experiments
 tb_dir: /home/user/inpainting-lama/tb_logs
 pretrained_models: /home/user/inpainting-lama/
+# path to model checkpoint that will be loaded before start of training
+# load_checkpoint_path: /home/user/lama/big-lama/models/best.ckpt


### PR DESCRIPTION
Small change introducing the option to provide a path (through location config) for model checkpoint to be used to load weights before starting a new training. I used this with success for finetuning LaMa model to my custom dataset.

CC: @senya-ashukha @cohimame 