### PR TITLE
Fix: Albumentations imports, Remove imgaug and Update torch model loading

### DIFF
--- a/saicinpainting/training/data/aug.py
+++ b/saicinpainting/training/data/aug.py
@@ -78,7 +78,7 @@ class IAAPerspective2(DualTransform):
 
     @property
     def processor(self):
-        return Perspective.PerspectiveTransform(self.scale, keep_size=self.keep_size, mode=self.mode, cval=self.cval)
+        return Perspective(self.scale, keep_size=self.keep_size, mode=self.mode, cval=self.cval)
 
     def get_transform_init_args_names(self):
         return ("scale", "keep_size")

--- a/saicinpainting/training/data/aug.py
+++ b/saicinpainting/training/data/aug.py
@@ -1,7 +1,7 @@
-from albumentations import DualIAATransform, to_tuple
-import imgaug.augmenters as iaa
+from albumentations import DualTransform, Affine, Perspective
+from albumentations.core.utils import to_tuple
 
-class IAAAffine2(DualIAATransform):
+class IAAAffine2(DualTransform):
     """Place a regular grid of points on the input and randomly move the neighbourhood of these point around
     via affine transformations.
 
@@ -39,7 +39,7 @@ class IAAAffine2(DualIAATransform):
 
     @property
     def processor(self):
-        return iaa.Affine(
+        return Affine(
             self.scale,
             self.translate_percent,
             self.translate_px,
@@ -54,7 +54,7 @@ class IAAAffine2(DualIAATransform):
         return ("scale", "translate_percent", "translate_px", "rotate", "shear", "order", "cval", "mode")
 
 
-class IAAPerspective2(DualIAATransform):
+class IAAPerspective2(DualTransform):
     """Perform a random four point perspective transform of the input.
 
     Note: This class introduce interpolation artifacts to mask if it has values other than {0;1}
@@ -78,7 +78,7 @@ class IAAPerspective2(DualIAATransform):
 
     @property
     def processor(self):
-        return iaa.PerspectiveTransform(self.scale, keep_size=self.keep_size, mode=self.mode, cval=self.cval)
+        return Perspective.PerspectiveTransform(self.scale, keep_size=self.keep_size, mode=self.mode, cval=self.cval)
 
     def get_transform_init_args_names(self):
         return ("scale", "keep_size")

--- a/saicinpainting/training/trainers/__init__.py
+++ b/saicinpainting/training/trainers/__init__.py
@@ -24,7 +24,7 @@ def make_training_model(config):
 
 def load_checkpoint(train_config, path, map_location='cuda', strict=True):
     model: torch.nn.Module = make_training_model(train_config)
-    state = torch.load(path, map_location=map_location)
+    state = torch.load(path, map_location=map_location, weights_only=False)
     model.load_state_dict(state['state_dict'], strict=strict)
     model.on_load_checkpoint(state)
     return model


### PR DESCRIPTION
- Update albumentations import to fix compatibility
- Remove imgaug as its no longer maintained and causing compatibility issues
- Change torch.load to have weights_only=False for proper loading of model with latest torch versions